### PR TITLE
Fix divided by zero crash in FEToEUProvider

### DIFF
--- a/src/main/java/gregfluxology/cap/FEToEUProvider.java
+++ b/src/main/java/gregfluxology/cap/FEToEUProvider.java
@@ -78,7 +78,8 @@ public class FEToEUProvider extends CapabilityCompatProvider {
             long maxIn = maxReceive / FeCompat.ratio(true);
             long missing = energyContainer.getEnergyCanBeInserted();
             long voltage = energyContainer.getInputVoltage();
-            if(voltage == 0) return 0;
+            if (voltage <= 0) return 0;
+            
             maxIn = Math.min(missing, maxIn);
             long maxAmp = Math.min(energyContainer.getInputAmperage(), maxIn / voltage);
 

--- a/src/main/java/gregfluxology/cap/FEToEUProvider.java
+++ b/src/main/java/gregfluxology/cap/FEToEUProvider.java
@@ -78,6 +78,7 @@ public class FEToEUProvider extends CapabilityCompatProvider {
             long maxIn = maxReceive / FeCompat.ratio(true);
             long missing = energyContainer.getEnergyCanBeInserted();
             long voltage = energyContainer.getInputVoltage();
+            if(voltage == 0) return 0;
             maxIn = Math.min(missing, maxIn);
             long maxAmp = Math.min(energyContainer.getInputAmperage(), maxIn / voltage);
 


### PR DESCRIPTION
The voltage may be 0, for example when the creative power source is active but with voltage set to 0, so I added a check to prevent a divided by zero crash